### PR TITLE
Update index.ts to fix the differenceInMonths function issue

### DIFF
--- a/src/differenceInMonths/index.ts
+++ b/src/differenceInMonths/index.ts
@@ -60,8 +60,14 @@ export default function differenceInMonths<DateType extends Date>(
     }
 
     result = sign * (difference - Number(isLastMonthNotFull))
+
+    // Check if start date is last day of Feb in leap year and end date is before last day of Feb
+    if (_dateLeft.getMonth() === 1 && _dateLeft.getDate() === 29 && _dateRight.getDate() < 29) {
+      result -= sign;
+    }
   }
 
   // Prevent negative zero
   return result === 0 ? 0 : result
 }
+


### PR DESCRIPTION
I have fixed the error in the leap year month calculation.

This was the issue which I have solved:

In leap year, the differenceInMonths function also counts the 28 February as the last day of February and returns a wrong number of months